### PR TITLE
Disable static libraries for the first build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
           - bash: |
               mkdir -p _build
               cd _build
-              ../configure
+              ../configure --disable-static
             displayName: Configure
           - bash: |
               cd _build


### PR DESCRIPTION
Disabling static libraries reduces the build time.