### PR TITLE
Change class template TestSuite to non-public

### DIFF
--- a/libcppunitx/bits/cppunitx/suite.h
+++ b/libcppunitx/bits/cppunitx/suite.h
@@ -38,7 +38,7 @@ namespace cppunitx
 {
     /// Test suite.
     template<class Fixture>
-    class _CPPUNITX_PUBLIC TestSuite: public TestRegistry::Registrant
+    class TestSuite: public TestRegistry::Registrant
     {
         using inherited = TestRegistry::Registrant;
 


### PR DESCRIPTION
`TestSuite` is to be instantiated by test modules.